### PR TITLE
feat: safe transaction builder json fork mode

### DIFF
--- a/USAGE.md
+++ b/USAGE.md
@@ -58,6 +58,9 @@ npm run modifiers:generate -- -n 1 -p V3 --fork --payload 0xYourPayloadAddress
 
 # Fork mode with raw calldata (see "Using Fork Mode" section)
 npm run modifiers:generate -- -n 1 -p V3 --fork --calldata 0xCalldata --caller 0xCallerAddress --target 0xTargetAddress
+
+# Fork mode with a Safe transaction builder json (see "Using Fork Mode" section)
+npm run modifiers:generate -- -n 1 -p V3 --fork --safe-json ./path/to/batch.json
 ```
 
 ### Generate Markdown Tables
@@ -76,11 +79,12 @@ npm run tables:create -- -n 1 -p V3
 |------|-------|-------------|
 | `--network <chainId>` | `-n` | Filter by network chain ID (repeatable) |
 | `--pool <poolKey>` | `-p` | Filter by pool key (repeatable, requires `--network`) |
-| `--fork` | `-f` | Enable fork mode (requires `--network`, `--pool`, and either `--payload` or `--calldata`) |
-| `--payload <address>` | | Payload address to execute on the fork (mutually exclusive with `--calldata`) |
-| `--calldata <hex>` | | Raw calldata to execute on the fork (mutually exclusive with `--payload`) |
+| `--fork` | `-f` | Enable fork mode (requires `--network`, `--pool`, and either `--payload`, `--calldata` or `--safe-json`) |
+| `--payload <address>` | | Payload address to execute on the fork (mutually exclusive with `--calldata`/`--safe-json`) |
+| `--calldata <hex>` | | Raw calldata to execute on the fork (mutually exclusive with `--payload`/`--safe-json`) |
 | `--caller <address>` | | Address to impersonate as the transaction sender (requires `--calldata`) |
 | `--target <address>` | | Target contract address for the calldata (requires `--calldata`) |
+| `--safe-json <file>` | | Safe transaction builder json batch to execute on the fork (mutually exclusive with `--payload`/`--calldata`) |
 
 ## How It Works
 
@@ -260,9 +264,10 @@ This is a more involved process. See the **[Adding Pool Types Guide](./ADDING_PO
 
 Fork mode uses [Anvil](https://book.getfoundry.sh/reference/anvil/) (from Foundry) to create a local fork of the blockchain, execute an action on it, and then index the resulting permission changes. This lets you see what permissions would change if the action were executed.
 
-There are two fork execution modes:
+There are three fork execution modes:
 - **Payload mode** (`--payload`): Executes an Aave governance payload through the PayloadsController.
 - **Calldata mode** (`--calldata`): Executes raw calldata by impersonating a caller address. Useful for simulating multisig transactions, direct contract calls, or any action that doesn't go through the Aave governance payload flow.
+- **Safe json mode** (`--safe-json`): Executes a json batch exported from the [Safe transaction builder](https://help.safe.global/en/articles/40841-transaction-builder) app. Each transaction of the batch is executed in order, impersonating the Safe (`meta.createdFromSafeAddress`).
 
 ### Prerequisites
 
@@ -283,6 +288,7 @@ curl -L https://foundry.paradigm.xyz | bash && foundryup
      - **Executed**: Throws an error (fork is not needed).
      - **Cancelled / Expired**: Throws an error (payload cannot be executed).
    - **Calldata mode** (`--calldata`): The caller address is impersonated using Anvil's `impersonateAccount`, funded with native token for gas, and the calldata is sent to the target contract. This works with any address, including multisigs (e.g., Gnosis Safe).
+   - **Safe json mode** (`--safe-json`): The Safe is impersonated and funded for gas, then every transaction of the batch is encoded (from `contractMethod`/`contractInputsValues`, or raw `data`) and sent in order. Since the targets only see the Safe as `msg.sender`, this produces the same state changes as executing the batch through `Safe.execTransaction` with owner signatures.
 3. **Permission indexing**: Events are indexed from mainnet first (up to the fork block), then from the fork (post-execution). The fork events are layered on top.
 4. **State queries**: All contract state reads (owner, guardian, roles, etc.) are made against the fork, reflecting the post-execution state.
 
@@ -337,6 +343,24 @@ npm run tables:create -- -n 1 -p V3
 git diff
 ```
 
+#### With a Safe transaction builder json
+
+```bash
+# 1. Create a branch for the review
+git checkout -b review/safe-batch-name
+
+# 2. Ensure the base permissions are up to date
+npm run modifiers:generate -- -n 1 -p V3
+npm run tables:create -- -n 1 -p V3
+
+# 3. Run fork mode with the json batch exported from the Safe transaction builder
+npm run modifiers:generate -- -n 1 -p V3 --fork --safe-json ./path/to/batch.json
+npm run tables:create -- -n 1 -p V3
+
+# 4. Review the diff
+git diff
+```
+
 ## Project Structure
 
 ```
@@ -362,7 +386,8 @@ git diff
 │   ├── tableGenerator.ts        # Markdown table rendering
 │   ├── decentralization.ts      # Ownership chain classification
 │   ├── poolHelpers.ts           # Provider resolution for fork/regular mode
-│   ├── anvil.ts                  # Anvil fork management, payload and calldata execution
+│   ├── anvil.ts                  # Anvil fork management, payload/calldata/safe batch execution
+│   ├── safeTxBuilder.ts          # Safe transaction builder json parsing and encoding
 │   ├── cli.ts                   # CLI argument parsing
 │   └── logger.ts                # Structured logging
 ├── statics/                     # Static permissions JSON files

--- a/helpers/anvil.ts
+++ b/helpers/anvil.ts
@@ -11,6 +11,10 @@ import {
 } from 'viem';
 import { getSolidityStorageSlotUint } from '@aave-dao/toolbox';
 import { PayloadsController_ABI } from '../abis/payloadsController.js';
+import {
+  encodeSafeTxBuilderTransaction,
+  SafeTxBuilderBatch,
+} from './safeTxBuilder.js';
 
 // ============================================================================
 // Types
@@ -331,6 +335,67 @@ export async function executeCalldataOnFork(
     console.log(`Calldata executed successfully (tx: ${hash})`);
   } finally {
     await client.stopImpersonatingAccount({ address: callerAddress });
+  }
+}
+
+/**
+ * Executes a Safe transaction builder batch on a running Anvil fork by
+ * impersonating the Safe and sending each transaction of the batch in order.
+ *
+ * Impersonating the Safe (instead of executing the batch through
+ * Safe.execTransaction with owner signatures) produces the same state changes,
+ * since the targets only see the Safe as msg.sender.
+ */
+export async function executeSafeBatchOnFork(
+  anvilRpcUrl: string,
+  batch: SafeTxBuilderBatch,
+): Promise<void> {
+  const client = createTestClient({
+    mode: 'anvil',
+    transport: http(anvilRpcUrl, { timeout: 120_000 }),
+  })
+    .extend(publicActions)
+    .extend(walletActions);
+
+  const safeAddress = batch.meta.createdFromSafeAddress as Address;
+
+  // Impersonate the Safe and fund it for gas
+  await client.impersonateAccount({ address: safeAddress });
+  await client.setBalance({
+    address: safeAddress,
+    value: 1000000000000000000n, // 1 native token
+  });
+
+  console.log(
+    `Executing safe batch "${batch.meta.name}" (${batch.transactions.length} transactions) as ${safeAddress}`,
+  );
+
+  try {
+    for (let i = 0; i < batch.transactions.length; i++) {
+      const tx = batch.transactions[i];
+      const calldata = encodeSafeTxBuilderTransaction(tx);
+
+      const hash = await client.sendTransaction({
+        chain: null,
+        account: safeAddress,
+        to: tx.to as Address,
+        data: calldata,
+        value: BigInt(tx.value || 0),
+      });
+
+      const receipt = await client.waitForTransactionReceipt({ hash });
+      if (receipt.status === 'reverted') {
+        throw new Error(
+          `Safe batch transaction ${i + 1}/${batch.transactions.length} to ${tx.to} reverted (tx: ${hash})`,
+        );
+      }
+
+      console.log(
+        `Safe batch transaction ${i + 1}/${batch.transactions.length} executed (tx: ${hash})`,
+      );
+    }
+  } finally {
+    await client.stopImpersonatingAccount({ address: safeAddress });
   }
 }
 

--- a/helpers/cli.ts
+++ b/helpers/cli.ts
@@ -8,6 +8,7 @@ export interface CliArgs {
   calldata?: string;
   caller?: string;
   target?: string;
+  safeJson?: string;
 }
 
 /**
@@ -21,6 +22,7 @@ export interface CliArgs {
  *   --calldata <hex>                       (requires --fork, mutually exclusive with --payload)
  *   --caller <address>                     (requires --calldata)
  *   --target <address>                     (requires --calldata)
+ *   --safe-json <file>                     (requires --fork, mutually exclusive with --payload/--calldata)
  */
 export const parseCliArgs = (): CliArgs => {
   const args = process.argv.slice(2);
@@ -50,17 +52,20 @@ export const parseCliArgs = (): CliArgs => {
     } else if (arg === '--target' && nextArg && !nextArg.startsWith('-')) {
       result.target = nextArg;
       i++;
+    } else if (arg === '--safe-json' && nextArg && !nextArg.startsWith('-')) {
+      result.safeJson = nextArg;
+      i++;
     }
   }
 
-  // Validate fork mode requires (payload) or (calldata+caller+target), plus network+pool
+  // Validate fork mode requires (payload), (calldata+caller+target) or (safe-json), plus network+pool
   if (result.fork) {
-    if (result.payload && result.calldata) {
-      console.error('--payload and --calldata are mutually exclusive');
+    if ([result.payload, result.calldata, result.safeJson].filter(Boolean).length > 1) {
+      console.error('--payload, --calldata and --safe-json are mutually exclusive');
       process.exit(1);
     }
-    if (!result.payload && !result.calldata) {
-      console.error('--fork requires either --payload <address> or --calldata <hex> --caller <address> --target <address>');
+    if (!result.payload && !result.calldata && !result.safeJson) {
+      console.error('--fork requires either --payload <address>, --calldata <hex> --caller <address> --target <address>, or --safe-json <file>');
       process.exit(1);
     }
     if (result.calldata) {
@@ -154,7 +159,9 @@ export const logExecutionConfig = (args: CliArgs): void => {
     ? `\n  Payload: ${args.payload}`
     : args.calldata
       ? `\n  Calldata: ${args.calldata}\n  Caller: ${args.caller}\n  Target: ${args.target}`
-      : '';
+      : args.safeJson
+        ? `\n  Safe json: ${args.safeJson}`
+        : '';
 
   console.log(`
 ========================================

--- a/helpers/eventIndexer.ts
+++ b/helpers/eventIndexer.ts
@@ -1,7 +1,12 @@
 import { Client, Log } from 'viem';
 import { getEventsMultiContract, getRpcClientFromUrl } from './rpc.js';
 import { getLimit } from './limits.js';
-import { executePayloadOnFork, executeCalldataOnFork } from './anvil.js';
+import {
+  executePayloadOnFork,
+  executeCalldataOnFork,
+  executeSafeBatchOnFork,
+} from './anvil.js';
+import { SafeTxBuilderBatch } from './safeTxBuilder.js';
 
 // ============================================================================
 // Types
@@ -72,6 +77,14 @@ export interface ForkCalldataConfig {
   calldata: string;
 }
 
+/**
+ * Fork safe batch configuration for executing a Safe transaction builder
+ * batch on the Anvil fork.
+ */
+export interface ForkSafeBatchConfig {
+  batch: SafeTxBuilderBatch;
+}
+
 // ============================================================================
 // Core Indexing Functions
 // ============================================================================
@@ -138,6 +151,7 @@ export const indexPoolEvents = async ({
   forkRpcUrl,
   forkPayload,
   forkCalldata,
+  forkSafeBatch,
 }: {
   client: Client;
   chainId: string | number;
@@ -147,6 +161,7 @@ export const indexPoolEvents = async ({
   forkRpcUrl?: string;
   forkPayload?: ForkPayloadConfig;
   forkCalldata?: ForkCalldataConfig;
+  forkSafeBatch?: ForkSafeBatchConfig;
 }): Promise<IndexingResult> => {
   const limit = getLimit(String(chainId));
 
@@ -197,9 +212,9 @@ export const indexPoolEvents = async ({
     latestBlockNumber = Math.max(latestBlockNumber, currentBlock);
   }
 
-  // Step 2: If fork mode, execute payload or calldata and fetch fork events
-  if (forkRpcUrl && (forkPayload || forkCalldata)) {
-    // Execute the payload or calldata on the Anvil fork
+  // Step 2: If fork mode, execute payload, calldata or safe batch and fetch fork events
+  if (forkRpcUrl && (forkPayload || forkCalldata || forkSafeBatch)) {
+    // Execute the payload, calldata or safe batch on the Anvil fork
     if (forkPayload) {
       await executePayloadOnFork(
         forkRpcUrl,
@@ -213,6 +228,8 @@ export const indexPoolEvents = async ({
         forkCalldata.target,
         forkCalldata.calldata,
       );
+    } else if (forkSafeBatch) {
+      await executeSafeBatchOnFork(forkRpcUrl, forkSafeBatch.batch);
     }
 
     // Fetch events from the fork starting from latestBlockNumber

--- a/helpers/safeTxBuilder.ts
+++ b/helpers/safeTxBuilder.ts
@@ -1,0 +1,154 @@
+import { readFileSync } from 'fs';
+import {
+  encodeFunctionData,
+  getAddress,
+  type AbiFunction,
+  type AbiParameter,
+  type Address,
+  type Hex,
+} from 'viem';
+
+/**
+ * A single transaction as exported by the Safe transaction builder app.
+ * Either `data` is set (raw calldata) or `contractMethod` + `contractInputsValues`
+ * describe the call to be encoded.
+ */
+export interface SafeTxBuilderTransaction {
+  to: Address;
+  value: string;
+  data: Hex | null;
+  contractMethod: {
+    inputs: AbiParameter[];
+    name: string;
+    payable: boolean;
+  } | null;
+  contractInputsValues: Record<string, string> | null;
+}
+
+/**
+ * The json format exported by the Safe transaction builder app.
+ */
+export interface SafeTxBuilderBatch {
+  version: string;
+  chainId: string;
+  createdAt: number;
+  meta: {
+    name: string;
+    description: string;
+    txBuilderVersion?: string;
+    createdFromSafeAddress: string;
+    createdFromOwnerAddress?: string;
+    checksum?: string;
+  };
+  transactions: SafeTxBuilderTransaction[];
+}
+
+/**
+ * Reads and validates a Safe transaction builder json file.
+ */
+export function parseSafeTxBuilderFile(filePath: string): SafeTxBuilderBatch {
+  const batch = JSON.parse(
+    readFileSync(filePath, 'utf8'),
+  ) as SafeTxBuilderBatch;
+  if (!batch.chainId) {
+    throw new Error(`${filePath} is missing chainId`);
+  }
+  if (!batch.transactions || batch.transactions.length === 0) {
+    throw new Error(`${filePath} contains no transactions`);
+  }
+  if (!batch.meta?.createdFromSafeAddress) {
+    throw new Error(`${filePath} is missing meta.createdFromSafeAddress`);
+  }
+  // Normalize / checksum-validate addresses
+  batch.meta.createdFromSafeAddress = getAddress(
+    batch.meta.createdFromSafeAddress,
+  );
+  batch.transactions = batch.transactions.map((tx) => ({
+    ...tx,
+    to: getAddress(tx.to),
+  }));
+  return batch;
+}
+
+/**
+ * Parses a stringified tx-builder value into json, quoting bare integer
+ * literals first so values above Number.MAX_SAFE_INTEGER keep full precision.
+ */
+function parseJsonValue(value: string): unknown {
+  const quoted = value.replace(
+    /-?\d+(?=(?:[^"]*"[^"]*")*[^"]*$)/g,
+    (match) => `"${match}"`,
+  );
+  return JSON.parse(quoted);
+}
+
+/**
+ * Converts a tx-builder input value (string encoded) into the shape viem
+ * expects for the given abi parameter.
+ */
+function parseInputValue(param: AbiParameter, value: unknown): unknown {
+  if (value === undefined || value === null) {
+    throw new Error(
+      `missing value for parameter ${param.name} (${param.type})`,
+    );
+  }
+  if (param.type.endsWith(']')) {
+    const elementType = param.type.slice(0, param.type.lastIndexOf('['));
+    const values = typeof value === 'string' ? parseJsonValue(value) : value;
+    if (!Array.isArray(values)) {
+      throw new Error(
+        `expected array for parameter ${param.name} (${param.type})`,
+      );
+    }
+    return values.map((v) =>
+      parseInputValue({ ...param, type: elementType }, v),
+    );
+  }
+  if (param.type === 'tuple') {
+    const components = (param as { components?: AbiParameter[] }).components;
+    if (!components) {
+      throw new Error(`missing components for tuple parameter ${param.name}`);
+    }
+    const values = typeof value === 'string' ? parseJsonValue(value) : value;
+    if (!Array.isArray(values) || values.length !== components.length) {
+      throw new Error(
+        `expected ${components.length} values for tuple parameter ${param.name}`,
+      );
+    }
+    return components.map((component, i) =>
+      parseInputValue(component, values[i]),
+    );
+  }
+  if (param.type.startsWith('uint') || param.type.startsWith('int')) {
+    return BigInt(value as string | number);
+  }
+  if (param.type === 'bool') {
+    return typeof value === 'boolean' ? value : value === 'true';
+  }
+  return value;
+}
+
+/**
+ * Returns the calldata of a single tx-builder transaction.
+ */
+export function encodeSafeTxBuilderTransaction(
+  tx: SafeTxBuilderTransaction,
+): Hex {
+  if (tx.data) return tx.data;
+  if (!tx.contractMethod) {
+    throw new Error(
+      `transaction to ${tx.to} has neither data nor contractMethod`,
+    );
+  }
+  const abiFunction: AbiFunction = {
+    type: 'function',
+    name: tx.contractMethod.name,
+    inputs: tx.contractMethod.inputs,
+    outputs: [],
+    stateMutability: tx.contractMethod.payable ? 'payable' : 'nonpayable',
+  };
+  const args = tx.contractMethod.inputs.map((input) =>
+    parseInputValue(input, tx.contractInputsValues?.[input.name!]),
+  );
+  return encodeFunctionData({ abi: [abiFunction], args });
+}

--- a/scripts/modifiersCalculator.ts
+++ b/scripts/modifiersCalculator.ts
@@ -74,7 +74,9 @@ import {
   buildPoolContractConfigs,
   ForkPayloadConfig,
   ForkCalldataConfig,
+  ForkSafeBatchConfig,
 } from '../helpers/eventIndexer.js';
+import { parseSafeTxBuilderFile } from '../helpers/safeTxBuilder.js';
 import { logger } from '../helpers/logger.js';
 import { checkAnvilInstalled, startAnvilFork, AnvilFork } from '../helpers/anvil.js';
 import {
@@ -95,9 +97,10 @@ const generateNetworkPermissions = async (
 
   const pools = networkConfigs[network].pools;
 
-  // Build fork payload or calldata config if in fork mode
+  // Build fork payload, calldata or safe batch config if in fork mode
   let forkPayload: ForkPayloadConfig | undefined;
   let forkCalldata: ForkCalldataConfig | undefined;
+  let forkSafeBatch: ForkSafeBatchConfig | undefined;
   if (args.fork && args.payload) {
     // Find the PayloadsController address from the governance address book.
     // First check the requested pools, then fall back to all pools on the network
@@ -122,6 +125,14 @@ const generateNetworkPermissions = async (
       target: args.target,
       calldata: args.calldata,
     };
+  } else if (args.fork && args.safeJson) {
+    const batch = parseSafeTxBuilderFile(args.safeJson);
+    if (Number(batch.chainId) !== network) {
+      throw new Error(
+        `Safe json chainId (${batch.chainId}) does not match --network (${network})`,
+      );
+    }
+    forkSafeBatch = { batch };
   }
 
   for (let i = 0; i < poolsToProcess.length; i++) {
@@ -196,6 +207,7 @@ const generateNetworkPermissions = async (
           forkRpcUrl,
           forkPayload,
           forkCalldata,
+          forkSafeBatch,
         });
 
         indexedEvents = indexResult.eventsByContract;


### PR DESCRIPTION
Adds a third fork execution mode, `--safe-json <file>`, next to `--payload` and `--calldata`. It takes a json batch exported from the Safe transaction builder app, impersonates the Safe on the anvil fork and executes every transaction of the batch in order (calldata encoded from `contractMethod`/`contractInputsValues`, or raw `data` when present). Since targets only see the Safe as msg.sender, the resulting permission diff is the same as executing through `Safe.execTransaction`.

```bash
npm run modifiers:generate -- -n 1 -p V4 --fork --safe-json ./batch.json
npm run tables:create -- -n 1 -p V4
git diff
```

Motivation: during the v4 hardening phase actions are executed by the security council multisig rather than governance payloads, and the existing `--calldata` mode only supports a single call. Tested against the Paxos replacement TokenizationSpokes activation batch (executes fine, no permission changes) and against a synthetic role-grant batch to confirm changes do surface in the tables. Docs added to USAGE.md.