### PR TITLE
review: Global Dollar replacement tokenization spokes

### DIFF
--- a/helpers/configs/networks/mainnet.ts
+++ b/helpers/configs/networks/mainnet.ts
@@ -134,6 +134,14 @@ for (const [key, address] of Object.entries(deduplicatedV4Addresses)) {
   }
 }
 
+// Paxos replacement TokenizationSpokes, not yet in the address book
+v4TokenizationSpokesAddressBook['PAXOS_USDC_REPLACEMENT_TOKENIZATION_SPOKE'] =
+  '0xFaB44fbD00C5056956BC1c4d681A80563E10d2fD';
+v4TokenizationSpokesAddressBook['PAXOS_USDT_REPLACEMENT_TOKENIZATION_SPOKE'] =
+  '0xF38C21AE3b87981e954c4eF6b5C1Cbd4BfB00E27';
+v4TokenizationSpokesAddressBook['PAXOS_PT_USDG_24SEP2026_REPLACEMENT_TOKENIZATION_SPOKE'] =
+  '0xB4086ae520EA1314b3EE7f899887acfD5ccdE406';
+
 const aaveV4 = createV4({
   accessManagerBlock: 24720870,
   tokenizationSpokesAddressBook: v4TokenizationSpokesAddressBook,

--- a/helpers/configs/networks/mainnet.ts
+++ b/helpers/configs/networks/mainnet.ts
@@ -134,13 +134,13 @@ for (const [key, address] of Object.entries(deduplicatedV4Addresses)) {
   }
 }
 
-// Paxos replacement TokenizationSpokes, not yet in the address book
-v4TokenizationSpokesAddressBook['PAXOS_USDC_REPLACEMENT_TOKENIZATION_SPOKE'] =
-  '0xFaB44fbD00C5056956BC1c4d681A80563E10d2fD';
-v4TokenizationSpokesAddressBook['PAXOS_USDT_REPLACEMENT_TOKENIZATION_SPOKE'] =
-  '0xF38C21AE3b87981e954c4eF6b5C1Cbd4BfB00E27';
-v4TokenizationSpokesAddressBook['PAXOS_PT_USDG_24SEP2026_REPLACEMENT_TOKENIZATION_SPOKE'] =
-  '0xB4086ae520EA1314b3EE7f899887acfD5ccdE406';
+// Global Dollar replacement TokenizationSpokes, not yet in the address book
+v4TokenizationSpokesAddressBook['GLOBAL_DOLLAR_USDC_REPLACEMENT_TOKENIZATION_SPOKE'] =
+  '0xaed7c529bD2878170B61C758DfAa215AC7a4FD07';
+v4TokenizationSpokesAddressBook['GLOBAL_DOLLAR_USDT_REPLACEMENT_TOKENIZATION_SPOKE'] =
+  '0xa0e97e45C2f89003730E467Bd484fA3eEcE5B4Cf';
+v4TokenizationSpokesAddressBook['GLOBAL_DOLLAR_PT_USDG_24SEP2026_REPLACEMENT_TOKENIZATION_SPOKE'] =
+  '0x7Df10B4A01350D2A1d95cFbE7c9207d7210A2663';
 
 const aaveV4 = createV4({
   accessManagerBlock: 24720870,

--- a/out/ETHEREUM-V4.md
+++ b/out/ETHEREUM-V4.md
@@ -59,6 +59,9 @@
 |  [PAXOS PT USDG 24SEP2026 TokenizationSpoke](https://etherscan.io/address/0x27eF1140364948A0E30E248297FfDFE5a4091ec4) |  0xdAbad81aF85554E9ae636395611C58F7eC1aAEc5 | |--------|--------|
 |  [PAXOS USDC TokenizationSpoke](https://etherscan.io/address/0x4131E0B2E7AFeCEAf3d3b4225aA61a3B2B7535b8) |  0xdAbad81aF85554E9ae636395611C58F7eC1aAEc5 | |--------|--------|
 |  [PAXOS USDT TokenizationSpoke](https://etherscan.io/address/0x8Dabe53E8cB991c57f0307F6f419E6D469b0deAA) |  0xdAbad81aF85554E9ae636395611C58F7eC1aAEc5 | |--------|--------|
+|  [PAXOS USDC REPLACEMENT TokenizationSpoke](https://etherscan.io/address/0xFaB44fbD00C5056956BC1c4d681A80563E10d2fD) |  V4 Security Council | |--------|--------|
+|  [PAXOS USDT REPLACEMENT TokenizationSpoke](https://etherscan.io/address/0xF38C21AE3b87981e954c4eF6b5C1Cbd4BfB00E27) |  V4 Security Council | |--------|--------|
+|  [PAXOS PT USDG 24SEP2026 REPLACEMENT TokenizationSpoke](https://etherscan.io/address/0xB4086ae520EA1314b3EE7f899887acfD5ccdE406) |  V4 Security Council | |--------|--------|
 
 ### Contracts
 | contract |proxyAdmin |modifier |permission owner |functions |

--- a/out/ETHEREUM-V4.md
+++ b/out/ETHEREUM-V4.md
@@ -59,9 +59,9 @@
 |  [PAXOS PT USDG 24SEP2026 TokenizationSpoke](https://etherscan.io/address/0x27eF1140364948A0E30E248297FfDFE5a4091ec4) |  0xdAbad81aF85554E9ae636395611C58F7eC1aAEc5 | |--------|--------|
 |  [PAXOS USDC TokenizationSpoke](https://etherscan.io/address/0x4131E0B2E7AFeCEAf3d3b4225aA61a3B2B7535b8) |  0xdAbad81aF85554E9ae636395611C58F7eC1aAEc5 | |--------|--------|
 |  [PAXOS USDT TokenizationSpoke](https://etherscan.io/address/0x8Dabe53E8cB991c57f0307F6f419E6D469b0deAA) |  0xdAbad81aF85554E9ae636395611C58F7eC1aAEc5 | |--------|--------|
-|  [PAXOS USDC REPLACEMENT TokenizationSpoke](https://etherscan.io/address/0xFaB44fbD00C5056956BC1c4d681A80563E10d2fD) |  V4 Security Council | |--------|--------|
-|  [PAXOS USDT REPLACEMENT TokenizationSpoke](https://etherscan.io/address/0xF38C21AE3b87981e954c4eF6b5C1Cbd4BfB00E27) |  V4 Security Council | |--------|--------|
-|  [PAXOS PT USDG 24SEP2026 REPLACEMENT TokenizationSpoke](https://etherscan.io/address/0xB4086ae520EA1314b3EE7f899887acfD5ccdE406) |  V4 Security Council | |--------|--------|
+|  [GLOBAL DOLLAR USDC REPLACEMENT TokenizationSpoke](https://etherscan.io/address/0xaed7c529bD2878170B61C758DfAa215AC7a4FD07) |  V4 Security Council | |--------|--------|
+|  [GLOBAL DOLLAR USDT REPLACEMENT TokenizationSpoke](https://etherscan.io/address/0xa0e97e45C2f89003730E467Bd484fA3eEcE5B4Cf) |  V4 Security Council | |--------|--------|
+|  [GLOBAL DOLLAR PT USDG 24SEP2026 REPLACEMENT TokenizationSpoke](https://etherscan.io/address/0x7Df10B4A01350D2A1d95cFbE7c9207d7210A2663) |  V4 Security Council | |--------|--------|
 
 ### Contracts
 | contract |proxyAdmin |modifier |permission owner |functions |

--- a/out/permissions/1-permissions.json
+++ b/out/permissions/1-permissions.json
@@ -12050,6 +12050,96 @@
               "functions": []
             }
           ]
+        },
+        "PAXOS USDC REPLACEMENT TokenizationSpoke": {
+          "address": "0xFaB44fbD00C5056956BC1c4d681A80563E10d2fD",
+          "modifiers": [],
+          "proxyAdmin": "0xe1b8fff9330ca9d0058a5afdad69d0fbc85a425f"
+        },
+        "_PAXOS USDC REPLACEMENT TokenizationSpoke ProxyAdmin": {
+          "address": "0xe1b8fff9330ca9d0058a5afdad69d0fbc85a425f",
+          "modifiers": [
+            {
+              "modifier": "onlyOwner",
+              "addresses": [
+                {
+                  "address": "0x187AAE17d4931310B3fc75743e7F16Bdc9eD77e9",
+                  "owners": [
+                    "0x9440850335c7C2a644dc2abEBBA93463c9736F2C",
+                    "0xbf113Fa52454A94185b65e6f2E818B7f178f937a",
+                    "0x75C26ED4D9c5D331665766394D933E12f8597a55",
+                    "0x437B97618dFB8c8B1f403Bd2E9436730f0f9D884",
+                    "0xc0A15667D6c63ac2CBFCAf5ABbFA0639018B2065",
+                    "0x9AB4e51a7cd8cE1279D9dbfA01Ad61367C3e3749",
+                    "0x76c82c2cB7C5dB3B053A251F3281081C6EC40FDF",
+                    "0x606dC57cd166643760E049609bfd1D8a698D3bAc"
+                  ],
+                  "signersThreshold": 5
+                }
+              ],
+              "functions": []
+            }
+          ]
+        },
+        "PAXOS USDT REPLACEMENT TokenizationSpoke": {
+          "address": "0xF38C21AE3b87981e954c4eF6b5C1Cbd4BfB00E27",
+          "modifiers": [],
+          "proxyAdmin": "0x09e816c2852da92d773de556552244ee128cfb2b"
+        },
+        "_PAXOS USDT REPLACEMENT TokenizationSpoke ProxyAdmin": {
+          "address": "0x09e816c2852da92d773de556552244ee128cfb2b",
+          "modifiers": [
+            {
+              "modifier": "onlyOwner",
+              "addresses": [
+                {
+                  "address": "0x187AAE17d4931310B3fc75743e7F16Bdc9eD77e9",
+                  "owners": [
+                    "0x9440850335c7C2a644dc2abEBBA93463c9736F2C",
+                    "0xbf113Fa52454A94185b65e6f2E818B7f178f937a",
+                    "0x75C26ED4D9c5D331665766394D933E12f8597a55",
+                    "0x437B97618dFB8c8B1f403Bd2E9436730f0f9D884",
+                    "0xc0A15667D6c63ac2CBFCAf5ABbFA0639018B2065",
+                    "0x9AB4e51a7cd8cE1279D9dbfA01Ad61367C3e3749",
+                    "0x76c82c2cB7C5dB3B053A251F3281081C6EC40FDF",
+                    "0x606dC57cd166643760E049609bfd1D8a698D3bAc"
+                  ],
+                  "signersThreshold": 5
+                }
+              ],
+              "functions": []
+            }
+          ]
+        },
+        "PAXOS PT USDG 24SEP2026 REPLACEMENT TokenizationSpoke": {
+          "address": "0xB4086ae520EA1314b3EE7f899887acfD5ccdE406",
+          "modifiers": [],
+          "proxyAdmin": "0x5a005989e689c7d8b0229e4900372cbe2ac1ec6d"
+        },
+        "_PAXOS PT USDG 24SEP2026 REPLACEMENT TokenizationSpoke ProxyAdmin": {
+          "address": "0x5a005989e689c7d8b0229e4900372cbe2ac1ec6d",
+          "modifiers": [
+            {
+              "modifier": "onlyOwner",
+              "addresses": [
+                {
+                  "address": "0x187AAE17d4931310B3fc75743e7F16Bdc9eD77e9",
+                  "owners": [
+                    "0x9440850335c7C2a644dc2abEBBA93463c9736F2C",
+                    "0xbf113Fa52454A94185b65e6f2E818B7f178f937a",
+                    "0x75C26ED4D9c5D331665766394D933E12f8597a55",
+                    "0x437B97618dFB8c8B1f403Bd2E9436730f0f9D884",
+                    "0xc0A15667D6c63ac2CBFCAf5ABbFA0639018B2065",
+                    "0x9AB4e51a7cd8cE1279D9dbfA01Ad61367C3e3749",
+                    "0x76c82c2cB7C5dB3B053A251F3281081C6EC40FDF",
+                    "0x606dC57cd166643760E049609bfd1D8a698D3bAc"
+                  ],
+                  "signersThreshold": 5
+                }
+              ],
+              "functions": []
+            }
+          ]
         }
       }
     },

--- a/out/permissions/1-permissions.json
+++ b/out/permissions/1-permissions.json
@@ -12051,13 +12051,13 @@
             }
           ]
         },
-        "PAXOS USDC REPLACEMENT TokenizationSpoke": {
-          "address": "0xFaB44fbD00C5056956BC1c4d681A80563E10d2fD",
+        "GLOBAL DOLLAR USDC REPLACEMENT TokenizationSpoke": {
+          "address": "0xaed7c529bD2878170B61C758DfAa215AC7a4FD07",
           "modifiers": [],
-          "proxyAdmin": "0xe1b8fff9330ca9d0058a5afdad69d0fbc85a425f"
+          "proxyAdmin": "0xd5022ba3cedee544a97962d7c55e2c70e4e3dd0d"
         },
-        "_PAXOS USDC REPLACEMENT TokenizationSpoke ProxyAdmin": {
-          "address": "0xe1b8fff9330ca9d0058a5afdad69d0fbc85a425f",
+        "_GLOBAL DOLLAR USDC REPLACEMENT TokenizationSpoke ProxyAdmin": {
+          "address": "0xd5022ba3cedee544a97962d7c55e2c70e4e3dd0d",
           "modifiers": [
             {
               "modifier": "onlyOwner",
@@ -12081,13 +12081,13 @@
             }
           ]
         },
-        "PAXOS USDT REPLACEMENT TokenizationSpoke": {
-          "address": "0xF38C21AE3b87981e954c4eF6b5C1Cbd4BfB00E27",
+        "GLOBAL DOLLAR USDT REPLACEMENT TokenizationSpoke": {
+          "address": "0xa0e97e45C2f89003730E467Bd484fA3eEcE5B4Cf",
           "modifiers": [],
-          "proxyAdmin": "0x09e816c2852da92d773de556552244ee128cfb2b"
+          "proxyAdmin": "0xeed53f90f1470d41c72cabc6ea996b11a47bc8ef"
         },
-        "_PAXOS USDT REPLACEMENT TokenizationSpoke ProxyAdmin": {
-          "address": "0x09e816c2852da92d773de556552244ee128cfb2b",
+        "_GLOBAL DOLLAR USDT REPLACEMENT TokenizationSpoke ProxyAdmin": {
+          "address": "0xeed53f90f1470d41c72cabc6ea996b11a47bc8ef",
           "modifiers": [
             {
               "modifier": "onlyOwner",
@@ -12111,13 +12111,13 @@
             }
           ]
         },
-        "PAXOS PT USDG 24SEP2026 REPLACEMENT TokenizationSpoke": {
-          "address": "0xB4086ae520EA1314b3EE7f899887acfD5ccdE406",
+        "GLOBAL DOLLAR PT USDG 24SEP2026 REPLACEMENT TokenizationSpoke": {
+          "address": "0x7Df10B4A01350D2A1d95cFbE7c9207d7210A2663",
           "modifiers": [],
-          "proxyAdmin": "0x5a005989e689c7d8b0229e4900372cbe2ac1ec6d"
+          "proxyAdmin": "0xd1650a62aeb378affd8e60b2582ffe8df27cc364"
         },
-        "_PAXOS PT USDG 24SEP2026 REPLACEMENT TokenizationSpoke ProxyAdmin": {
-          "address": "0x5a005989e689c7d8b0229e4900372cbe2ac1ec6d",
+        "_GLOBAL DOLLAR PT USDG 24SEP2026 REPLACEMENT TokenizationSpoke ProxyAdmin": {
+          "address": "0xd1650a62aeb378affd8e60b2582ffe8df27cc364",
           "modifiers": [
             {
               "modifier": "onlyOwner",

--- a/out/permissions/metadata/1-metadata.json
+++ b/out/permissions/metadata/1-metadata.json
@@ -150,7 +150,7 @@
     }
   },
   "V4": {
-    "latestBlockNumber": 25577492,
+    "latestBlockNumber": 25582206,
     "indexedContracts": {
       "ACCESS_MANAGER": {
         "address": "0x08aE3BE30958cDd1847ec58fFfd4C451a87fDF01",

--- a/out/permissions/metadata/1-metadata.json
+++ b/out/permissions/metadata/1-metadata.json
@@ -150,7 +150,7 @@
     }
   },
   "V4": {
-    "latestBlockNumber": 25582206,
+    "latestBlockNumber": 25630398,
     "indexedContracts": {
       "ACCESS_MANAGER": {
         "address": "0x08aE3BE30958cDd1847ec58fFfd4C451a87fDF01",


### PR DESCRIPTION
Review-only, not meant to be merged — adds the three Global Dollar replacement TokenizationSpokes (activated by the security council batch, not yet in the address book) to the mainnet config so their upgradeability shows up in the tables.

The diff shows the new spokes are upgradeable by the V4 Security Council, while the three old spokes they replace have their ProxyAdmins owned by the PayloadsController (`0xdAbad81…`). Config entries should come from the address book once it includes these addresses.
